### PR TITLE
Fix stack underflow

### DIFF
--- a/main.s
+++ b/main.s
@@ -156,7 +156,7 @@ Loop::
   bit 2, [hl]       ; check if up on the joypad is pressed
   bit 2, [hl]       ; check if up on the joypad is pressed
   
-  jp z, MoveScreen  ; if 0(pressed) jump to label
+  call z, MoveScreen  ; if 0(pressed) jump to label
 
   jp Loop
 


### PR DESCRIPTION
MoveScreen wasn't called but jumped to, which caused the stack to underflow when that function returned.
The game still running after that is pure luck, I think it actually was rebooting; the reason why the scroll still worked is that the game doesn't init the scroll regs, instead using the values left over by the boot ROM.