### PR TITLE
Fix sprite not appearing

### DIFF
--- a/wram.s
+++ b/wram.s
@@ -4,6 +4,7 @@ SECTION "Stack", WRAM0
     ds 64
 wStackBottom::
 
-SECTION "OAM Vars",WRAM0[$C100]
+SECTION "Shadow OAM",WRAM0,ALIGN[8]
 
-playerSprite:: DS 4
+wShadowOAM::
+    ds 40 * 4


### PR DESCRIPTION
- Fix OAM DMA target location
- Set bit 2 of LCDC
- Move OAM DMA copy to before interrupt enable to avoid race condition
- Clear shadow OAM Y positions
- Move player sprite init to after "init", since it's not part of "base" init
- Init player sprite's attribute as well
- Rename "playerSprite" to "wShadowOAM" to better match naming convention, and to designate the whole array

/!\\ WARNING: You probably don't want to re-poll OAM on every frame; you should only do so when the main code sets a flag. Having that flag being the value to write to `rDMA` is a good idea.